### PR TITLE
Added `ipython` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aeskeyschedule
 python-sat
 git+https://github.com/jellevos/fhegen.git
 matplotlib
+ipython


### PR DESCRIPTION
`ipython` package is required in `oraqle/compiler/circuit.py`, but it is not present in `requirements.txt` or `requirements_dev.txt`